### PR TITLE
jakub_bugfixes to master

### DIFF
--- a/dbhydra/dbhydra_core.py
+++ b/dbhydra/dbhydra_core.py
@@ -1728,7 +1728,7 @@ class XlsxDB(AbstractDB):
         self.locally=True
         if db_details is None:
             self.name="new_db"
-            self.directory_path = None
+            self.db_directory_path = None
         else:
             self.name = db_details.get("DB_DATABASE")
             self.db_directory_path = db_details.get("DB_DIRECTORY")


### PR DESCRIPTION
BUGFIX: corrected typo crashing XlsxDB initialization without DB_details when using Database module in Forloop Desktop

Necessary to merge for new Forloop Desktop release.