### PR TITLE
daniel/minor-fixes-2 --> master

### DIFF
--- a/dbhydra/src/abstract_table.py
+++ b/dbhydra/src/abstract_table.py
@@ -241,10 +241,6 @@ class AbstractTable(AbstractJoinable, abc.ABC):
         if self.columns is not None and self.types is not None:
             assert len(self.columns) == len(self.types)
             
-            # Hotfix: flatten nested lists (otherwise crashes might happen)
-            # TODO: Search for the causes and implement better handling
-            for i, column in enumerate(self.columns):
-                self.columns[i] = column[0] if type(column) == list else column
             self.column_type_dict={self.columns[i]:self.types[i] for i,x in enumerate(self.columns)}
         else:
             self.column_type_dict={}

--- a/dbhydra/src/tables.py
+++ b/dbhydra/src/tables.py
@@ -635,6 +635,14 @@ class MysqlTable(AbstractTable):
         information_schema_table = Table(self.db1, 'INFORMATION_SCHEMA.COLUMNS')
         query = f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{self.db1.DB_DATABASE}' AND TABLE_NAME  = '" + self.name + "'"
         columns = information_schema_table.select(query)
+        
+        if isinstance(columns, AbstractSelectable):
+            return columns
+        
+        # SQL might return the column names as a list of lists containing column names one by one instead of a list of names.
+        # --> in these cases the list is flattened
+        for i, column in enumerate(self.columns):
+            self.columns[i] = column[0] if type(column) == list else column
 
         return (columns)
 

--- a/dbhydra/src/tables.py
+++ b/dbhydra/src/tables.py
@@ -641,8 +641,8 @@ class MysqlTable(AbstractTable):
         
         # SQL might return the column names as a list of lists containing column names one by one instead of a list of names.
         # --> in these cases the list is flattened
-        for i, column in enumerate(self.columns):
-            self.columns[i] = column[0] if type(column) == list else column
+        for i, column in enumerate(columns):
+            columns[i] = column[0] if type(column) == list else column
 
         return (columns)
 


### PR DESCRIPTION
Moves the fix of nested column names list into `MySQLTable.get_all_columns` method. I think the flattening is necessary as the query gets columns as rows --> we get `list[list[str]]`

So far I added the fix just into `MySQLTable` but it is possible that something similar would need to be done for Postgres and others as well.